### PR TITLE
会員登録の通知でパスワードでなく、パスワード再発行URL付けるように修正

### DIFF
--- a/Controller/ForgotPassController.php
+++ b/Controller/ForgotPassController.php
@@ -171,6 +171,8 @@ class ForgotPassController extends AuthAppController {
 				return $this->redirect('/auth/forgot_pass/confirm');
 			}
 			$this->NetCommons->handleValidationError($this->ForgotPass->validationErrors);
+		} else {
+			$this->request->data['ForgotPass']['email'] = Hash::get($this->request->query, 'email');
 		}
 	}
 


### PR DESCRIPTION
https://github.com/NetCommons3/UserManager/issues/56
