### PR TITLE
半角英数字・記号のエラーメッセージの文言追加

### DIFF
--- a/View/ForgotPass/update.ctp
+++ b/View/ForgotPass/update.ctp
@@ -31,7 +31,7 @@
 			<?php echo $this->NetCommonsForm->input('User.password', array(
 				'type' => 'password',
 				'label' => __d('auth', 'New password'),
-				'placeholder' => __d('net_commons', 'Only alphabets and numbers are allowed.'),
+				'placeholder' => __d('net_commons', 'Only alphabets, numbers and symbols are allowed.'),
 				'required' => true,
 				'again' => true
 			)); ?>


### PR DESCRIPTION
https://github.com/NetCommons3/NetCommons3/issues/682
