### PR TITLE
移行後にnc2パスワードでログインできない不具合対応

### DIFF
--- a/Controller/AuthController.php
+++ b/Controller/AuthController.php
@@ -51,6 +51,10 @@ class AuthController extends AuthAppController {
 		$this->set('authenticators', $authenticators);
 
 		$this->__setDefaultAuthenticator();
+		// @see https://book.cakephp.org/2.0/ja/core-libraries/components/authentication.html#id5
+		// 認証ハンドラは $this->Auth->authenticate を使って設定します。
+		// コントローラの beforeFilter の中、もしくは $components 配列の中に、 認証ハンドラ()を設定することができます。
+		$this->_setNc2Authenticate();
 
 		parent::beforeFilter();
 		$this->Auth->allow('login', 'logout');
@@ -87,7 +91,7 @@ class AuthController extends AuthAppController {
 		$this->set('isMailSend', $this->ForgotPass->isMailSendCommon('auth', 'auth'));
 
 		if ($this->request->is('post')) {
-			$this->_setNc2Authenticate();
+			//$this->_setNc2Authenticate();
 
 			if ($this->Auth->login()) {
 				$this->User->updateLoginTime($this->Auth->user('id'));


### PR DESCRIPTION
3.1.7リリースした位の時期からnc2パスワードでログインできなくなったので修正しました。
原因は、認証ハンドラの書く位置が違ってました。
バグ修正のため、トラビステスト通ったら、マージしようと思ってます。

### 詳細、認証ハンドラの書く位置が違う

cakephp2の認証ハンドラが設定できるのは、コントローラの beforeFilter の中、もしくは $components 配列の中でした。
https://book.cakephp.org/2.0/ja/core-libraries/components/authentication.html#id5

ドキュメントの通りであれば、Authの_setNc2Authenticate()は、login()で呼び出していたので、認証ハンドラがききませんでした。
https://github.com/NetCommons3/Auth/blob/3.1.7/Controller/AuthController.php#L90
（以前はこのコードでも動いていた（バグってたんだと思う）ので、cakeのコアに修正入ったんだと思います。）

