### PR TITLE
新規登録で、項目の選択肢「チェックボックス」を登録可能にする

### DIFF
--- a/Model/AutoUserRegist.php
+++ b/Model/AutoUserRegist.php
@@ -155,7 +155,7 @@ class AutoUserRegist extends AppModel {
  * @return string model名(UserもしくはUsersLanguage)
  */
 	private function __getModel($userAttribute) {
-		if (Hash::get($userAttribute, 'UserAttribute.is_multilingualization')) {
+		if (Hash::get($userAttribute, 'UserAttributeSetting.is_multilingualization')) {
 			$model = 'UsersLanguage';
 		} else {
 			$model = 'User';

--- a/View/Helper/AutoUserRegistFormHelper.php
+++ b/View/Helper/AutoUserRegistFormHelper.php
@@ -119,12 +119,18 @@ class AutoUserRegistFormHelper extends AppHelper {
 		$options['help'] = $userAttribute['UserAttribute']['description'];
 
 		$options['div'] = array('class' => 'form-group' . $colClass);
-		if (in_array($dataTypeKey, ['radio', 'checkbox', 'select'], true)) {
+		if (in_array($dataTypeKey, ['radio', 'select'], true)) {
 			$options['options'] = Hash::combine(
 				$userAttribute['UserAttributeChoice'], '{n}.code', '{n}.name'
 			);
-		}
-		if (in_array($dataTypeKey, ['password', 'email'], true)) {
+		} else if (in_array($dataTypeKey, ['checkbox'], true)) {
+			// チェックボックスは 'multiple' => 'checkbox' を設定しないと、$this->request->dataの値が反映されない
+			$options += [
+				'options' => Hash::combine($userAttribute['UserAttributeChoice'], '{n}.code', '{n}.name'),
+				'multiple' => 'checkbox',
+				'class' => 'checkbox-inline nc-checkbox',
+			];
+		} else if (in_array($dataTypeKey, ['password', 'email'], true)) {
 			$options['again'] = ! $disabled;
 		}
 


### PR DESCRIPTION
https://github.com/NetCommons3/NetCommons3/issues/1209

~~バグ直ってません。~~
~~修正を試みましたが、会員新規登録と会員管理の登録とで、処理が異なっているため、~~
~~修正追えませんでした。~~

とりあえずテーブル名違いの不具合修正をプルリクエストします。

