### PR TITLE
feat(login): redirect when Router::fullBaseUrl() is not same as App.loginUrl

### DIFF
--- a/Controller/AuthController.php
+++ b/Controller/AuthController.php
@@ -98,6 +98,14 @@ class AuthController extends AuthAppController {
  * @throws InternalErrorException
  **/
 	public function login() {
+		// ログイン機能をサブドメインにする変更のために、App.loginUrl を追加して
+		// ログイン画面のURLが違ったら転送するようにする
+		$loginUrl = Configure::read('App.loginUrl');
+		if ($loginUrl != "" && Router::fullBaseUrl() != $loginUrl) {
+		    $this->redirect($loginUrl . '/auth/login');
+		    return;
+		}
+
 		//ページタイトル
 		$this->set('pageTitle', __d('auth', 'Login'));
 


### PR DESCRIPTION
## やったこと
application.yml に App.loginUrl を定義した状態で、

なお、楽に確認するためには https://github.com/NetCommons3/NetCommons/pull/561 とかがはいっているといいです。
 `example.com.yml` と `secure.example.com.yml` を用意して、example.com.yml には、fullBaseUrl と loginUrlを定義すると、テストがやりやすくなります。

## なぜやるか
CDNで http://example.com はキャッシュして、http://secure.example.com はキャッシュしない。
でも、http://example.com から、利用者はほぼ考えることなく、 http://secure.example.com に遷移できるようにしたい。
ログイン画面に遷移しようとした時に、自動的に遷移させるようにすると、利用者は考えなくても遷移できているはずだ。と言う考えから実装しました。

もっとNC3の深いところから、secureとnon-secureを分けて動作するようにするのもよいかと思ったんですが、影響範囲が大きくなって、テストが難しくなるので、シンプルに分けるようにしました。

## レビュー観点
- loginUrl と言うコンフィグ名の妥当性
   - もっとなんかいい名前を考えたいですn
