### PR TITLE
change: パスワード再発行で登録されていないメールアドレスを入力した場合、正常としていたが、エラーとするように修正

### DIFF
--- a/Controller/ForgotPassController.php
+++ b/Controller/ForgotPassController.php
@@ -147,6 +147,9 @@ class ForgotPassController extends AuthAppController {
 
 				//対象のユーザがいる場合は、メール送る。
 				//成否を出すと、悪意ある人がやった場合、メールアドレスがバレてしまうため、送ったことにする。
+				//⇒有名どころのWebサービスでは、エラーを表示している。
+				//　かなり昔では、送らない方が良かったかもしれないが、新規登録などで既に登録されているなどの
+				//　エラーを返すことから、この回避方法は意味がないため、エラーを返すようにする。
 				if (Hash::get($forgotPass, 'user_id')) {
 					$this->mail->mailAssignTag->setFixedPhraseSubject(
 						SiteSettingUtil::read('ForgotPass.issue_mail_subject')

--- a/Locale/eng/LC_MESSAGES/auth.po
+++ b/Locale/eng/LC_MESSAGES/auth.po
@@ -65,6 +65,9 @@ msgstr ""
 msgid "Forgot your Password?"
 msgstr ""
 
+msgid "The email address entered is invalid."
+msgstr ""
+
 #: Auth/Controller/ForgotPassController.php:164
 #: Auth/Test/Case/Controller/ForgotPassController/RequestTest.php:216;301
 msgid "We have sent you the key to obtain a new password to your registered e-mail address."

--- a/Locale/jpn/LC_MESSAGES/auth.po
+++ b/Locale/jpn/LC_MESSAGES/auth.po
@@ -67,6 +67,9 @@ msgstr "アカウントを承認できませんでした。<br>システム管�
 msgid "Forgot your Password?"
 msgstr "パスワード再発行"
 
+msgid "The email address entered is invalid."
+msgstr "このメールアドレスは登録されていません。"
+
 #: Auth/Controller/ForgotPassController.php:164
 #: Auth/Test/Case/Controller/ForgotPassController/RequestTest.php:216;301
 msgid "We have sent you the key to obtain a new password to your registered e-mail address."

--- a/Model/ForgotPass.php
+++ b/Model/ForgotPass.php
@@ -129,6 +129,14 @@ class ForgotPass extends AppModel {
 			'conditions' => $conditions,
 		));
 
+		if (empty($user['User']['id'])) {
+			$this->invalidate(
+				'email',
+				__d('auth', 'The email address entered is invalid.')
+			);
+			return false;
+		}
+
 		$forgotPass = $this->create(array(
 			'user_id' => Hash::get($user, 'User.id', '0'),
 			'username' => Hash::get($user, 'User.username'),

--- a/Test/Case/Model/ForgotPass/ValidateRequestTest.php
+++ b/Test/Case/Model/ForgotPass/ValidateRequestTest.php
@@ -92,43 +92,19 @@ class ForgotPassValidateRequestTest extends NetCommonsModelTestCase {
 		$index = 2;
 		$result[$index] = array();
 		$result[$index]['email'] = 'aaaaa@exapmle.com';
-		$result[$index]['expected'] = array(
-			'ForgotPass' => array(
-				'user_id' => '0',
-				'username' => '',
-				'handlename' => '',
-				'authorization_key' => 'a',
-				'email' => $result[$index]['email'],
-			)
-		);
+		$result[$index]['expected'] = false;
 
 		//3: 削除されたユーザ、emailアドレス
 		$index = 3;
 		$result[$index] = array();
 		$result[$index]['email'] = 'deleted_1@exapmle.com';
-		$result[$index]['expected'] = array(
-			'ForgotPass' => array(
-				'user_id' => '0',
-				'username' => '',
-				'handlename' => '',
-				'authorization_key' => 'a',
-				'email' => $result[$index]['email'],
-			)
-		);
+		$result[$index]['expected'] = false;
 
 		//4: 削除されたユーザ、mobile_emailアドレス
 		$index = 4;
 		$result[$index] = array();
 		$result[$index]['email'] = 'deleted_2@exapmle.com';
-		$result[$index]['expected'] = array(
-			'ForgotPass' => array(
-				'user_id' => '0',
-				'username' => '',
-				'handlename' => '',
-				'authorization_key' => 'a',
-				'email' => $result[$index]['email'],
-			)
-		);
+		$result[$index]['expected'] = false;
 
 		//5: validationエラー
 		$index = 5;


### PR DESCRIPTION
https://github.com/researchmap/RmNetCommons3/issues/2653